### PR TITLE
Fixes a bug: passing jacobian tensors as `kwargs` in forward passes of `nnj`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode dev
+.vscode

--- a/stochman/nnj.py
+++ b/stochman/nnj.py
@@ -85,14 +85,14 @@ class Sequential(nn.Sequential):
     def forward(
         self, x: Tensor, jacobian: Union[Tensor, bool] = False
     ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
-        if jacobian:
+        if not (jacobian is False):
             j = identity(x) if (not isinstance(jacobian, Tensor) and jacobian) else jacobian
         for module in self._modules.values():
             val = module(x)
-            if jacobian:
+            if not (jacobian is False):
                 j = module._jacobian_wrt_input_mult_left_vec(x, val, j)
             x = val
-        if jacobian:
+        if not (jacobian is False):
             return x, j
         return x
 

--- a/tests/test_nnj.py
+++ b/tests/test_nnj.py
@@ -169,3 +169,13 @@ class TestJacobian:
         else:
             assert isinstance(output, torch.Tensor)
             assert str(output.device) == device
+
+
+def test_jac_works_in_separate_sequentials():
+    """Tests if you can provide a Jacobian tensor as a kwarg"""
+    first_sequential = nnj.Sequential(nnj.Linear(3, 2), nnj.Tanh())
+    second_sequential = nnj.Sequential(nnj.Linear(2, 1), nnj.Tanh())
+
+    inputs = torch.randn((10, 3))
+    hidden_values, first_jacobian = first_sequential(inputs, jacobian=True)
+    _, _ = second_sequential(hidden_values, jacobian=first_jacobian)


### PR DESCRIPTION
Solves the bug described in #21, and adds a test for this scenario.

The solution isn't pythonic, so I'm happy to refactor the logic a little bit more.